### PR TITLE
BaseConfiguration is now instanciable

### DIFF
--- a/DependencyInjection/BaseConfiguration.php
+++ b/DependencyInjection/BaseConfiguration.php
@@ -24,7 +24,7 @@ use Mmoreram\BaseBundle\Mapping\MappingBagProvider;
 /**
  * Class BaseConfiguration.
  */
-abstract class BaseConfiguration implements ConfigurationInterface
+class BaseConfiguration implements ConfigurationInterface
 {
     /**
      * @var string

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,6 @@
             "vendor/bin/php-formatter f:h:f .",
             "vendor/bin/php-formatter f:u:s ."
         ],
-        "test": "phpunit"
+        "test": "vendor/bin/phpunit"
     }
 }


### PR DESCRIPTION
* When the configuration is only used for exposing the mapping information, then you should use BaseConfiguration.
* As soon as you add some configuration, then you can add your own and overwrite.