### PR TITLE
Parametrizations moved outside Configuration check

### DIFF
--- a/DependencyInjection/BaseExtension.php
+++ b/DependencyInjection/BaseExtension.php
@@ -111,10 +111,10 @@ abstract class BaseExtension implements
 
             $config = $this->processConfiguration($configuration, $config);
             $config = $container->getParameterBag()->resolveValue($config);
-            $this->applyMappingParametrization($config, $container);
-            $this->applyParametrizedValues($config, $container);
         }
 
+        $this->applyMappingParametrization($config, $container);
+        $this->applyParametrizedValues($config, $container);
         $this->overrideEntities($container);
         $this->preLoad($config, $container);
     }


### PR DESCRIPTION
* Even if there's no configuration in a bundle, both mapping and simple parametrization values should be called