### PR TITLE
Added simple base bundle

### DIFF
--- a/DependencyInjection/SimpleBaseExtension.php
+++ b/DependencyInjection/SimpleBaseExtension.php
@@ -1,0 +1,141 @@
+<?php
+
+/*
+ * This file is part of the BaseBundle for Symfony2.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Mmoreram\BaseBundle\DependencyInjection;
+
+use Symfony\Component\Config\Definition\ConfigurationInterface;
+use Symfony\Component\HttpKernel\Bundle\BundleInterface;
+
+use Mmoreram\BaseBundle\Mapping\MappingBagProvider;
+
+/**
+ * Class SimpleBaseExtension.
+ */
+class SimpleBaseExtension extends BaseExtension
+{
+    /**
+     * @var BundleInterface
+     *
+     * Bundle
+     */
+    private $bundle;
+
+    /**
+     * @var array
+     *
+     * Config files
+     */
+    private $configFiles;
+
+    /**
+     * SimpleBaseExtension constructor.
+     *
+     * @param BundleInterface    $bundle
+     * @param array              $configFiles
+     * @param MappingBagProvider $mappingBagProvider
+     */
+    public function __construct(
+        BundleInterface $bundle,
+        array $configFiles,
+        MappingBagProvider $mappingBagProvider = null)
+    {
+        parent::__construct($mappingBagProvider);
+
+        $this->bundle = $bundle;
+        $this->configFiles = $configFiles;
+    }
+
+    /**
+     * Returns the recommended alias to use in XML.
+     *
+     * This alias is also the mandatory prefix to use when using YAML.
+     *
+     * @return string The alias
+     */
+    public function getAlias()
+    {
+        return strtolower(
+            preg_replace(
+                '/(?<!^)[A-Z]/',
+                '_$0',
+                preg_replace(
+                    '~Bundle$~',
+                    '',
+                    $this->bundle->getName()
+                )
+            )
+        );
+    }
+
+    /**
+     * Get the Config file location.
+     *
+     * @return string
+     */
+    protected function getConfigFilesLocation() : string
+    {
+        return $this
+            ->bundle
+            ->getPath() . '/Resources/config';
+    }
+
+    /**
+     * Config files to load.
+     *
+     * Each array position can be a simple file name if must be loaded always,
+     * or an array, with the filename in the first position, and a boolean in
+     * the second one.
+     *
+     * As a parameter, this method receives all loaded configuration, to allow
+     * setting this boolean value from a configuration value.
+     *
+     * return array(
+     *      'file1.yml',
+     *      'file2.yml',
+     *      ['file3.yml', $config['my_boolean'],
+     *      ...
+     * );
+     *
+     * @param array $config Config definitions
+     *
+     * @return array Config files
+     */
+    protected function getConfigFiles(array $config) : array
+    {
+        return $this->configFiles;
+    }
+
+    /**
+     * Return a new Configuration instance.
+     *
+     * If object returned by this method is an instance of
+     * ConfigurationInterface, extension will use the Configuration to read all
+     * bundle config definitions.
+     *
+     * Also will call getParametrizationValues method to load some config values
+     * to internal parameters.
+     *
+     * @return ConfigurationInterface|null
+     */
+    protected function getConfigurationInstance() : ? ConfigurationInterface
+    {
+        return $this->mappingBagProvider
+            ? new BaseConfiguration(
+                $this->getAlias(),
+                $this->mappingBagProvider
+            )
+            : null;
+    }
+}

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ about these three big blocks.
     * [Extension declaration](#extension-declaration)
     * [Compiler Pass declaration](#compiler-pass-declaration)
     * [Commands declaration](#commands-declaration)
+    * [SimpleBaseBundle](#simplebasebundle)
 * [Extension](#extension)
     * [Extending BaseExtension](#extending-baseextension)
     * [Implementing EntitiesOverridableExtension](#implementing-entitiesoverridableextension)
@@ -283,6 +284,120 @@ your domain. You can define your commands as services, injecting there all you
 need to make it work.
 
 [How to define commands as services](http://symfony.com/doc/current/cookbook/console/commands_as_services.html)
+
+### SimpleBaseBundle
+
+Even simpler.
+
+If you think about what is Symfony, about your project stages where you use
+Symfony and about how strict you should be about your code, always depending on
+your real needs, you should notice that there should be always a place for RAD
+(Rapid Application Development), always taking in account that the price spent
+later for changing from RAD to a non-that-rapid-development should be as cheap
+as possible.
+
+So, for your RAD applications, do you really think you need more than one single
+class to create a simple bundle? Not at all.
+
+Please, welcome SimpleBaseBundle, a simple way of creating Bundles with one
+class for your RAD applications.
+
+``` php
+use Mmoreram\BaseBundle\Mapping\MappingBagProvider;
+use Mmoreram\BaseBundle\SimpleBaseBundle;
+use Symfony\Component\HttpKernel\KernelInterface;
+
+/**
+ * Class TestSimpleBundle
+ */
+class TestSimpleBundle extends SimpleBaseBundle
+{
+    /**
+     * get config files
+     */
+    public function getConfigFiles() : array
+    {
+        return [
+            'services'
+        ];
+    }
+
+    /**
+     * get mapping bag provider
+     */
+    public function getMappingBagProvider() : ? MappingBagProvider
+    {
+        return new class implements MappingBagProvider {
+
+            /**
+             * Get mapping bag collection.
+             *
+             * @return MappingBagCollection
+             */
+            public function getMappingBagCollection() : MappingBagCollection
+            {
+                return MappingBagCollection::create(
+                    ['user' => 'User'],
+                    '@TestSimpleBundle',
+                    'Mmoreram\BaseBundle\Tests\Bundle\Entity'
+                );
+            }
+        };
+    }
+    
+    /**
+     * Register Commands.
+     *
+     * Disabled as commands are registered as services.
+     *
+     * @param Application $application An Application instance
+     */
+    public function registerCommands(Application $application)
+    {
+        return;
+    }
+
+    /**
+     * Return a CompilerPass instance array.
+     *
+     * @return CompilerPassInterface[]
+     */
+    public function getCompilerPasses()
+    {
+        return [];
+    }
+
+    /**
+     * Create instance of current bundle, and return dependent bundle namespaces.
+     *
+     * @return array Bundle instances
+     */
+    public static function getBundleDependencies(KernelInterface $kernel)
+    {
+        return [];
+    }
+}
+```
+
+and that's it. 
+
+With this class, you will create the bundle with its dependencies, you will
+initialize the commands and the Compiler Passes if needed, you will load the
+config files and you will initialize the entities with the given configuration
+defined in the MappingBagProvider.
+
+No need to create a DependencyInjection folder.
+
+> The method getMappingBagProvider can return null if you delegate to Doctrine
+> on auto_mapping feature, and can return a real MappingBagProvider instance if
+> you have the class in a file or an anonymous class as exposed in the example.
+> If the mapping configuration defined that the mapping data is overwritable,
+> then a MappingCompilerPass will be appended in your defined Compiler Passes,
+> so there's no need to define it.
+
+If your project takes another dimension or quality degree, then feel free to
+change your bundle implementation and start extending BaseBundle and adding this
+DependencyInjection folder.
 
 ## Extension
 

--- a/SimpleBaseBundle.php
+++ b/SimpleBaseBundle.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * This file is part of the BaseBundle for Symfony2.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Mmoreram\BaseBundle;
+
+use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
+use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
+
+use Mmoreram\BaseBundle\CompilerPass\MappingCompilerPass;
+use Mmoreram\BaseBundle\DependencyInjection\SimpleBaseExtension;
+use Mmoreram\BaseBundle\Mapping\MappingBagProvider;
+
+/**
+ * Class AbstractBundle.
+ */
+class SimpleBaseBundle extends BaseBundle
+{
+    /**
+     * get config files.
+     */
+    public function getConfigFiles() : array
+    {
+        return [];
+    }
+
+    /**
+     * get mapping bag provider.
+     */
+    public function getMappingBagProvider() : ? MappingBagProvider
+    {
+        return null;
+    }
+
+    /**
+     * Returns the bundle's container extension.
+     *
+     * @return ExtensionInterface|null The container extension
+     *
+     * @throws \LogicException
+     */
+    public function getContainerExtension()
+    {
+        return new SimpleBaseExtension(
+            $this,
+            $this->getConfigFiles(),
+            $this->getMappingBagProvider()
+        );
+    }
+
+    /**
+     * Return a CompilerPass instance array.
+     *
+     * @return CompilerPassInterface[]
+     */
+    public function getCompilerPasses()
+    {
+        $mappingBagProvider = $this->getMappingBagProvider();
+
+        return $mappingBagProvider instanceof MappingBagProvider
+            ? array_merge(
+                parent::getCompilerPasses(),
+                [new MappingCompilerPass($mappingBagProvider)]
+            )
+            : parent::getCompilerPasses();
+    }
+}

--- a/Tests/Bundle/Entity/User.php
+++ b/Tests/Bundle/Entity/User.php
@@ -59,7 +59,7 @@ class User implements UserInterface
      *
      * @param string|null $name
      */
-    public function setName( ? string $name)
+    public function setName(? string $name)
     {
         $this->name = $name;
     }

--- a/Tests/Bundle/Entity/UserInterface.php
+++ b/Tests/Bundle/Entity/UserInterface.php
@@ -39,5 +39,5 @@ interface UserInterface
      *
      * @param string|null $name
      */
-    public function setName( ? string $name);
+    public function setName(? string $name);
 }

--- a/Tests/Bundle/TestSimpleBundle.php
+++ b/Tests/Bundle/TestSimpleBundle.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the BaseBundle for Symfony2.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Mmoreram\BaseBundle\Tests\Bundle;
+
+use Symfony\Component\HttpKernel\KernelInterface;
+
+use Mmoreram\BaseBundle\Mapping\MappingBagProvider;
+use Mmoreram\BaseBundle\SimpleBaseBundle;
+
+/**
+ * Class TestSimpleBundle.
+ */
+class TestSimpleBundle extends SimpleBaseBundle
+{
+    /**
+     * @var MappingBagProvider
+     *
+     * Mapping bag provider
+     */
+    private $mappingBagProvider;
+
+    /**
+     * TestMappingBundle constructor.
+     *
+     * @param MappingBagProvider $mappingBagProvider
+     */
+    public function __construct(MappingBagProvider $mappingBagProvider)
+    {
+        $this->mappingBagProvider = $mappingBagProvider;
+    }
+
+    /**
+     * get config files.
+     */
+    public function getConfigFiles() : array
+    {
+        return [
+            'services',
+        ];
+    }
+
+    /**
+     * get mapping bag provider.
+     */
+    public function getMappingBagProvider() : ? MappingBagProvider
+    {
+        return $this->mappingBagProvider;
+    }
+
+    /**
+     * Create instance of current bundle, and return dependent bundle namespaces.
+     *
+     * @return array Bundle instances
+     */
+    public static function getBundleDependencies(KernelInterface $kernel)
+    {
+        return [
+            'Symfony\Bundle\FrameworkBundle\FrameworkBundle',
+            'Doctrine\Bundle\DoctrineBundle\DoctrineBundle',
+            'Mmoreram\BaseBundle\BaseBundle',
+        ];
+    }
+}

--- a/Tests/SimpleBaseBundleAnonymousTest.php
+++ b/Tests/SimpleBaseBundleAnonymousTest.php
@@ -1,0 +1,67 @@
+<?php
+
+/*
+ * This file is part of the BaseBundle for Symfony2.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Mmoreram\BaseBundle\Tests;
+
+use Symfony\Component\HttpKernel\KernelInterface;
+
+use Mmoreram\BaseBundle\Mapping\MappingBagCollection;
+use Mmoreram\BaseBundle\Mapping\MappingBagProvider;
+use Mmoreram\BaseBundle\Tests\Bundle\TestSimpleBundle;
+
+/**
+ * Class SimpleBaseBundleAnonymousTest.
+ */
+class SimpleBaseBundleAnonymousTest extends BaseFunctionalTest
+{
+    /**
+     * Get kernel.
+     *
+     * @return KernelInterface
+     */
+    protected static function getKernel() : KernelInterface
+    {
+        return new BaseKernel([
+            new TestSimpleBundle(new class() implements MappingBagProvider {
+                /**
+                 * Get mapping bag collection.
+                 *
+                 * @return MappingBagCollection
+                 */
+                public function getMappingBagCollection() : MappingBagCollection
+                {
+                    return MappingBagCollection::create(
+                        ['user' => 'User'],
+                        '@TestSimpleBundle',
+                        'Mmoreram\BaseBundle\Tests\Bundle\Entity'
+                    );
+                }
+            }),
+        ], [
+            'imports' => [
+                ['resource' => '@BaseBundle/Resources/config/providers.yml'],
+                ['resource' => '@BaseBundle/Resources/test/doctrine.test.yml'],
+            ],
+        ]);
+    }
+
+    /**
+     * Test mapping data.
+     */
+    public function testMappingData()
+    {
+        $this->assertTrue($this->has('object_manager.user'));
+    }
+}

--- a/Tests/SimpleBaseBundleTest.php
+++ b/Tests/SimpleBaseBundleTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * This file is part of the BaseBundle for Symfony2.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Mmoreram\BaseBundle\Tests;
+
+use Symfony\Component\HttpKernel\KernelInterface;
+
+use Mmoreram\BaseBundle\Tests\Bundle\DependencyInjection\TestMappingBagProvider;
+use Mmoreram\BaseBundle\Tests\Bundle\TestSimpleBundle;
+
+/**
+ * Class SimpleBaseBundleTest.
+ */
+class SimpleBaseBundleTest extends BaseFunctionalTest
+{
+    /**
+     * Get kernel.
+     *
+     * @return KernelInterface
+     */
+    protected static function getKernel() : KernelInterface
+    {
+        return new BaseKernel([
+            new TestSimpleBundle(new TestMappingBagProvider(
+                ['user' => 'User'],
+                '@TestSimpleBundle',
+                'Mmoreram\BaseBundle\Tests\Bundle\Entity',
+                '',
+                'default',
+                'doctrine_manager',
+                'repo',
+                true
+            )),
+        ], [
+            'imports' => [
+                ['resource' => '@BaseBundle/Resources/config/providers.yml'],
+                ['resource' => '@BaseBundle/Resources/test/doctrine.test.yml'],
+            ],
+            'doctrine' => [
+                'orm' => [
+                    'entity_managers' => [
+                        'default' => [
+                            'connection' => 'default',
+                            'auto_mapping' => false,
+                        ],
+                        'another_manager' => [
+                            'connection' => 'default',
+                            'auto_mapping' => false,
+                        ],
+                    ],
+                ],
+            ],
+            'test_simple' => [
+                'mapping' => [
+                    'user' => [
+                        'manager' => 'another_manager',
+                    ],
+                ],
+            ],
+        ]);
+    }
+
+    /**
+     * Test the bundle instances properly.
+     */
+    public function testBundleInstance()
+    {
+        $this->assertTrue($this->has('base.object_manager_provider'));
+    }
+
+    /**
+     * Test mapping data.
+     */
+    public function testMappingData()
+    {
+        $this->assertTrue($this->has('doctrine_manager.user'));
+        $this->assertTrue($this->has('repo.user'));
+        $this->assertSame(
+            $this->get('doctrine_manager.user'),
+            $this->get('doctrine.orm.another_manager_entity_manager')
+        );
+    }
+}


### PR DESCRIPTION
Even simpler.

Make a RAD bundle with one single class. In this class you will be able to define:
* Bundle dependencies
* Bundle commands
* Bundle CompilerPasses
* Entities mapping configuration with no need of extra classes, just using ^PHP7 anonymous classes
* Bundle service resources in yml extension