### PR TITLE
Updated command feature in bundle

### DIFF
--- a/BaseBundle.php
+++ b/BaseBundle.php
@@ -16,6 +16,7 @@ declare(strict_types=1);
 namespace Mmoreram\BaseBundle;
 
 use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Command\Command;
 use Symfony\Component\DependencyInjection\Compiler\CompilerPassInterface;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Extension\ExtensionInterface;
@@ -61,13 +62,23 @@ class BaseBundle extends Bundle implements DependentBundleInterface
     /**
      * Register Commands.
      *
-     * Disabled as commands are registered as services.
-     *
-     * @param Application $application An Application instance
+     * @param Application $application
      */
     public function registerCommands(Application $application)
     {
-        return;
+        foreach ($this->getCommands() as $command) {
+            $application->register($command);
+        }
+    }
+
+    /**
+     * Get command instance array.
+     *
+     * @return Command[]
+     */
+    public function getCommands() : array
+    {
+        return [];
     }
 
     /**
@@ -75,17 +86,19 @@ class BaseBundle extends Bundle implements DependentBundleInterface
      *
      * @return CompilerPassInterface[]
      */
-    public function getCompilerPasses()
+    public function getCompilerPasses() : array
     {
         return [];
     }
 
     /**
-     * Create instance of current bundle, and return dependent bundle namespaces.
+     * Return all bundle dependencies.
      *
-     * @return array Bundle instances
+     * Values can be a simple bundle namespace or its instance
+     *
+     * @return array
      */
-    public static function getBundleDependencies(KernelInterface $kernel)
+    public static function getBundleDependencies(KernelInterface $kernel) : array
     {
         return [];
     }

--- a/README.md
+++ b/README.md
@@ -253,7 +253,7 @@ classes, and the bundle should know it in a very explicit way.
 
 By default, this BaseBundle abstract class removes the Command autoload,
 allowing you, in your main Bundle class, to return an array of Command
-instances.
+instances. By default, this method returns empty array.
 
 ``` php
 /**
@@ -264,14 +264,13 @@ abstract class BaseBundle extends Bundle
     // ...
 
     /**
-     * Register Commands.
+     * Get command instance array
      *
-     * Disabled as commands are registered as services.
-     *
-     * @param Application $application An Application instance
+     * @return Command[]
      */
-    public function registerCommands(Application $application)
+    public function getCommands() : array
     {
+        return [];
     }
 
     // ...
@@ -343,15 +342,13 @@ class TestSimpleBundle extends SimpleBaseBundle
     }
     
     /**
-     * Register Commands.
+     * Get command instance array
      *
-     * Disabled as commands are registered as services.
-     *
-     * @param Application $application An Application instance
+     * @return Command[]
      */
-    public function registerCommands(Application $application)
+    public function getCommands() : array
     {
-        return;
+        return [];
     }
 
     /**

--- a/SimpleBaseBundle.php
+++ b/SimpleBaseBundle.php
@@ -29,6 +29,8 @@ class SimpleBaseBundle extends BaseBundle
 {
     /**
      * get config files.
+     *
+     * @return array
      */
     public function getConfigFiles() : array
     {
@@ -37,6 +39,8 @@ class SimpleBaseBundle extends BaseBundle
 
     /**
      * get mapping bag provider.
+     *
+     * @return MappingBagProvider|null
      */
     public function getMappingBagProvider() : ? MappingBagProvider
     {
@@ -64,7 +68,7 @@ class SimpleBaseBundle extends BaseBundle
      *
      * @return CompilerPassInterface[]
      */
-    public function getCompilerPasses()
+    public function getCompilerPasses() : array
     {
         $mappingBagProvider = $this->getMappingBagProvider();
 

--- a/Tests/BaseBundleTest.php
+++ b/Tests/BaseBundleTest.php
@@ -34,9 +34,9 @@ class BaseBundleTest extends BaseFunctionalTest
     protected static function getKernel() : KernelInterface
     {
         return new BaseKernel([
-            new FrameworkBundle(),
-            new BaseBundle(),
-            new DoctrineBundle(),
+            FrameworkBundle::class,
+            BaseBundle::class,
+            DoctrineBundle::class,
         ], [
             'imports' => [
                 ['resource' => '@BaseBundle/Resources/config/providers.yml'],

--- a/Tests/BaseKernel.php
+++ b/Tests/BaseKernel.php
@@ -23,7 +23,7 @@ use Symfony\Component\HttpKernel\Kernel;
 use Symfony\Component\Routing\RouteCollectionBuilder;
 use Symfony\Component\Yaml\Yaml;
 
-use Mmoreram\SymfonyBundleDependencies\CachedBundleDependenciesResolver;
+use Mmoreram\SymfonyBundleDependencies\BundleDependenciesResolver;
 
 /**
  * Class BaseKernel.
@@ -31,7 +31,7 @@ use Mmoreram\SymfonyBundleDependencies\CachedBundleDependenciesResolver;
 final class BaseKernel extends Kernel
 {
     use MicroKernelTrait;
-    use CachedBundleDependenciesResolver;
+    use BundleDependenciesResolver;
 
     /**
      * @var string[]

--- a/Tests/Bundle/TestBundle.php
+++ b/Tests/Bundle/TestBundle.php
@@ -33,7 +33,7 @@ final class TestBundle extends BaseBundle
      *
      * @return CompilerPassInterface[]
      */
-    public function getCompilerPasses()
+    public function getCompilerPasses() : array
     {
         return [
             new TestCompilerPass(),
@@ -41,11 +41,15 @@ final class TestBundle extends BaseBundle
     }
 
     /**
-     * Create instance of current bundle, and return dependent bundle namespaces.
+     * Return all bundle dependencies.
      *
-     * @return array Bundle instances
+     * Values can be a simple bundle namespace or its instance
+     *
+     * @param KernelInterface $kernel
+     *
+     * @return array
      */
-    public static function getBundleDependencies(KernelInterface $kernel)
+    public static function getBundleDependencies(KernelInterface $kernel) : array
     {
         return [
             'Symfony\Bundle\FrameworkBundle\FrameworkBundle',

--- a/Tests/Bundle/TestEmptyBundle.php
+++ b/Tests/Bundle/TestEmptyBundle.php
@@ -25,11 +25,15 @@ use Mmoreram\BaseBundle\BaseBundle;
 final class TestEmptyBundle extends BaseBundle
 {
     /**
-     * Create instance of current bundle, and return dependent bundle namespaces.
+     * Return all bundle dependencies.
      *
-     * @return array Bundle instances
+     * Values can be a simple bundle namespace or its instance
+     *
+     * @param KernelInterface $kernel
+     *
+     * @return array
      */
-    public static function getBundleDependencies(KernelInterface $kernel)
+    public static function getBundleDependencies(KernelInterface $kernel) : array
     {
         return [
             'Symfony\Bundle\FrameworkBundle\FrameworkBundle',

--- a/Tests/Bundle/TestEntityBundle.php
+++ b/Tests/Bundle/TestEntityBundle.php
@@ -33,7 +33,7 @@ final class TestEntityBundle extends BaseBundle
      *
      * @return CompilerPassInterface[]
      */
-    public function getCompilerPasses()
+    public function getCompilerPasses() : array
     {
         return [
             new MappingCompilerPass(new TestStandardMappingBagProvider()),
@@ -41,11 +41,15 @@ final class TestEntityBundle extends BaseBundle
     }
 
     /**
-     * Create instance of current bundle, and return dependent bundle namespaces.
+     * Return all bundle dependencies.
      *
-     * @return array Bundle instances
+     * Values can be a simple bundle namespace or its instance
+     *
+     * @param KernelInterface $kernel
+     *
+     * @return array
      */
-    public static function getBundleDependencies(KernelInterface $kernel)
+    public static function getBundleDependencies(KernelInterface $kernel) : array
     {
         return [
             'Symfony\Bundle\FrameworkBundle\FrameworkBundle',

--- a/Tests/Bundle/TestMappingBundle.php
+++ b/Tests/Bundle/TestMappingBundle.php
@@ -51,7 +51,7 @@ final class TestMappingBundle extends BaseBundle
      *
      * @return CompilerPassInterface[]
      */
-    public function getCompilerPasses()
+    public function getCompilerPasses() : array
     {
         return [
             new MappingCompilerPass($this->mappingBagProvider),
@@ -59,11 +59,15 @@ final class TestMappingBundle extends BaseBundle
     }
 
     /**
-     * Create instance of current bundle, and return dependent bundle namespaces.
+     * Return all bundle dependencies.
      *
-     * @return array Bundle instances
+     * Values can be a simple bundle namespace or its instance
+     *
+     * @param KernelInterface $kernel
+     *
+     * @return array
      */
-    public static function getBundleDependencies(KernelInterface $kernel)
+    public static function getBundleDependencies(KernelInterface $kernel) : array
     {
         return [
             'Symfony\Bundle\FrameworkBundle\FrameworkBundle',

--- a/Tests/Bundle/TestSimpleBundle.php
+++ b/Tests/Bundle/TestSimpleBundle.php
@@ -61,11 +61,15 @@ class TestSimpleBundle extends SimpleBaseBundle
     }
 
     /**
-     * Create instance of current bundle, and return dependent bundle namespaces.
+     * Return all bundle dependencies.
      *
-     * @return array Bundle instances
+     * Values can be a simple bundle namespace or its instance
+     *
+     * @param KernelInterface $kernel
+     *
+     * @return array
      */
-    public static function getBundleDependencies(KernelInterface $kernel)
+    public static function getBundleDependencies(KernelInterface $kernel) : array
     {
         return [
             'Symfony\Bundle\FrameworkBundle\FrameworkBundle',

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "symfony/http-kernel": "^3.2",
         "symfony/config": "^3.2",
         "symfony/console": "^3.2",
-        "mmoreram/symfony-bundle-dependencies": "^1.0"
+        "mmoreram/symfony-bundle-dependencies": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.6.4",


### PR DESCRIPTION
* registerCommands should never be used again. If you have commands registered
  as services, no need to change anything. Otherwise, use getCommands() method
  to return an array of Command instances
* Updated symfony-bundle-dependencies version to work with strict mode