### PR TITLE
Added director as a default stack element

### DIFF
--- a/ORM/Director.php
+++ b/ORM/Director.php
@@ -1,0 +1,115 @@
+<?php
+
+/*
+ * This file is part of the BaseBundle for Symfony2.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Mmoreram\BaseBundle\ORM;
+
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\Common\Persistence\ObjectRepository;
+
+/**
+ * Class Director.
+ */
+class Director
+{
+    /**
+     * @var ObjectManager
+     *
+     * Object manager
+     */
+    private $objectManager;
+
+    /**
+     * @var ObjectRepository
+     *
+     * Object repository
+     */
+    private $objectRepository;
+
+    /**
+     * Director constructor.
+     *
+     * @param ObjectManager    $objectManager
+     * @param ObjectRepository $objectRepository
+     */
+    public function __construct(
+        ObjectManager $objectManager,
+        ObjectRepository $objectRepository
+    ) {
+        $this->objectManager = $objectManager;
+        $this->objectRepository = $objectRepository;
+    }
+
+    /**
+     * Finds an object by its primary key / identifier.
+     *
+     * @param mixed $id
+     *
+     * @return object
+     */
+    public function find($id)
+    {
+        return $this
+            ->objectRepository
+            ->find($id);
+    }
+
+    /**
+     * Finds a single object by a set of criteria.
+     *
+     * @param array $criteria
+     *
+     * @return object
+     */
+    public function findOneBy(array $criteria)
+    {
+        return $this
+            ->objectRepository
+            ->findOneBy($criteria);
+    }
+
+    /**
+     * Save an entity.
+     *
+     * @param object $entity
+     */
+    public function save($entity)
+    {
+        $this
+            ->objectManager
+            ->persist($entity);
+
+        $this
+            ->objectManager
+            ->flush($entity);
+    }
+
+    /**
+     * Removes an object instance.
+     *
+     * A removed object will be removed from the database as a result of the flush operation.
+     *
+     * @param object $object
+     */
+    public function remove($object)
+    {
+        $this
+            ->objectManager
+            ->remove($object);
+
+        $this
+            ->objectManager
+            ->flush($object);
+    }
+}

--- a/Tests/ORM/DirectorTest.php
+++ b/Tests/ORM/DirectorTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * This file is part of the BaseBundle for Symfony2.
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+declare(strict_types=1);
+
+namespace Mmoreram\BaseBundle\Tests\ORM;
+
+use Symfony\Component\HttpKernel\KernelInterface;
+
+use Mmoreram\BaseBundle\Tests\BaseFunctionalTest;
+use Mmoreram\BaseBundle\Tests\BaseKernel;
+use Mmoreram\BaseBundle\Tests\Bundle\DependencyInjection\TestMappingBagProvider;
+use Mmoreram\BaseBundle\Tests\Bundle\Entity\User;
+use Mmoreram\BaseBundle\Tests\Bundle\TestMappingBundle;
+
+/**
+ * File header placeholder.
+ */
+class DirectorTest extends BaseFunctionalTest
+{
+    /**
+     * Get kernel.
+     *
+     * @return KernelInterface
+     */
+    protected static function getKernel() : KernelInterface
+    {
+        return new BaseKernel([
+            new TestMappingBundle(new TestMappingBagProvider(
+                ['user' => 'User'],
+                '@TestMappingBundle',
+                'Mmoreram\BaseBundle\Tests\Bundle\Entity'
+            )),
+        ], [
+            'imports' => [
+                ['resource' => '@BaseBundle/Resources/config/providers.yml'],
+                ['resource' => '@BaseBundle/Resources/test/framework.test.yml'],
+                ['resource' => '@BaseBundle/Resources/test/doctrine.test.yml'],
+            ],
+            'parameters' => [
+                'rand' => 'rueyiw',
+            ],
+        ]);
+    }
+
+    /**
+     * Schema must be loaded in all test cases.
+     *
+     * @return bool
+     */
+    protected static function loadSchema() : bool
+    {
+        return true;
+    }
+
+    /**
+     * Test director behavior.
+     */
+    public function testDirectorBehavior()
+    {
+        $this->assertTrue($this->has('director.user'));
+        $director = $this->get('director.user');
+        $this->assertNull($director->find(1));
+
+        $user = new User();
+        $user->setName('Marc');
+        $director->save($user);
+
+        $this->assertNotNull($director->find(1));
+        $director->remove($user);
+        $this->assertNull($director->find(1));
+    }
+}


### PR DESCRIPTION
* When you define your entities, a new Mmoreram\BaseBundle\ORM\Director instance is created as well
* Each director instance can be used for a simple entity management, not for bulk treatment.
* Only 4 simple methods: find, findOneBy, save, remove