### PR TITLE
Add support to Symfony^6.0 as compatible version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,40 @@
 version: 2
 jobs:
 
-  test-php80:
+  test-php80-symfony6:
+    docker:
+      - image: circleci/php:8.0-cli
+
+    working_directory: ~/project
+    steps:
+      - checkout
+
+      - run:
+          name: Install PHPUnit
+          command: |
+            composer require mmoreram/symfony-bundle-dependencies:^2.2 --no-update
+
+      - run:
+          name: Run tests / Symfony 6^0
+          command: |
+            composer update -n --prefer-dist --no-suggest
+            php vendor/bin/phpunit --testsuite=with-bundle-dependencies
+
+  test-php80-symfony6-no-dependencies:
+    docker:
+      - image: circleci/php:8.0-cli
+
+    working_directory: ~/project
+    steps:
+      - checkout
+
+      - run:
+          name: Run tests / Symfony 6^0
+          command: |
+            composer update -n --prefer-dist --no-suggest
+            php vendor/bin/phpunit --testsuite=no-bundle-dependencies
+
+  test-php80-symfony5:
     docker:
       - image: circleci/php:8.0-cli
 
@@ -18,25 +51,29 @@ jobs:
           name: Run tests / Symfony 5^0
           command: |
             composer update -n --prefer-dist --no-suggest
+            composer require "symfony/framework-bundle:^5.1" "symfony/yaml:^5.1" --with-all-dependencies
             php vendor/bin/phpunit --testsuite=with-bundle-dependencies
 
-  test-php80-no-dependencies:
-    docker:
-      - image: circleci/php:8.0-cli
+  test-php80-symfony5-no-dependencies:
+      docker:
+        - image: circleci/php:8.0-cli
 
-    working_directory: ~/project
-    steps:
-      - checkout
+      working_directory: ~/project
+      steps:
+        - checkout
 
-      - run:
-          name: Run tests / Symfony 5^0
-          command: |
-            composer update -n --prefer-dist --no-suggest
-            php vendor/bin/phpunit --testsuite=no-bundle-dependencies
+        - run:
+            name: Run tests / Symfony 5^0
+            command: |
+              composer update -n --prefer-dist --no-suggest
+              composer require "symfony/framework-bundle:^5.1" "symfony/yaml:^5.1" --with-all-dependencies
+              php vendor/bin/phpunit --testsuite=no-bundle-dependencies
 
 workflows:
   version: 2
   test:
     jobs:
-      - test-php80
-      - test-php80-no-dependencies
+      - test-php80-symfony6
+      - test-php80-symfony6-no-dependencies
+      - test-php80-symfony5
+      - test-php80-symfony5-no-dependencies

--- a/Kernel/BaseKernelTrait.php
+++ b/Kernel/BaseKernelTrait.php
@@ -89,7 +89,7 @@ trait BaseKernelTrait
      *
      * @return BundleInterface[] An array of bundle instances
      */
-    public function registerBundles()
+    public function registerBundles(): iterable
     {
         return $this->getBundleInstances(
             $this,
@@ -179,7 +179,7 @@ trait BaseKernelTrait
      *
      * @return string The project root dir
      */
-    public function getProjectDir()
+    public function getProjectDir(): string
     {
         if (!is_null($this->rootDirPrefix)) {
             return $this->rootDirPrefix;

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 -----
 
-> The minimum requirements of this bundle is **PHP 7.2** and **Symfony 4.3** 
+> The minimum requirements of this bundle is **PHP 8.0** and **Symfony 5.1** 
 > because the bundle is using features on both versions. If you're not using
 > them yet, I encourage you to do it.
 

--- a/composer.json
+++ b/composer.json
@@ -13,16 +13,16 @@
     ],
     "require": {
         "php": "^8",
-        "symfony/framework-bundle": "^5.1",
-        "symfony/yaml": "^5.1",
+        "symfony/framework-bundle": "^5.1|^6.0",
+        "symfony/yaml": "^5.1|^6.0",
         "mmoreram/symfony-bundle-dependencies": "^2.3"
     },
     "require-dev": {
-        "symfony/http-kernel": "^5.1",
-        "symfony/console": "^5.1",
-        "symfony/process":  "^5.1",
-        "symfony/config": "^5.1",
-        "symfony/browser-kit": "^5.1",
+        "symfony/http-kernel": "^5.1|^6.0",
+        "symfony/console": "^5.1|^6.0",
+        "symfony/process":  "^5.1|^6.0",
+        "symfony/config": "^5.1|^6.0",
+        "symfony/browser-kit": "^5.1|^6.0",
         "phpunit/phpunit": "^9"
     },
     "autoload": {


### PR DESCRIPTION
I need support for Symfony 6. 

The required changes are:
- Update composer.json.
- Update BaseKernelTrait to be compatible with KernelInterface.
- Update readme.md to fix minimal requirements.